### PR TITLE
Add flag to disallow half-integral ratings

### DIFF
--- a/DJWStarRatingView/DJWStarRatingView.h
+++ b/DJWStarRatingView/DJWStarRatingView.h
@@ -66,6 +66,12 @@
 @property (nonatomic, assign) BOOL allowsSwipeWhenEditable;
 
 /**
+ *  Allows ratings at half-integer boundaries aswell as integers. Defaults to `YES`.
+ */
+@property (nonatomic, assign) BOOL allowsHalfIntegralRatings;
+
+
+/**
  *  An instance of DJWStarRatingView. The designated initializer for this class.
  *
  *  @param starSize      size of individual star

--- a/DJWStarRatingView/DJWStarRatingView.m
+++ b/DJWStarRatingView/DJWStarRatingView.m
@@ -34,6 +34,7 @@
         
         _allowsSwipeWhenEditable = YES;
         _allowsTapWhenEditable = YES;
+        _allowsHalfIntegralRatings = YES;
         
         self.backgroundColor = [UIColor clearColor];
         self.frame = CGRectMake(0, 0, self.intrinsicContentSize.width, self.intrinsicContentSize.height);
@@ -82,6 +83,8 @@
     CGFloat rating = (x / starWidthWithPadding) + 1;
     CGFloat fractional = fmodf(rating, 1);
     fractional = roundf(fractional * 2.0) / 2.0;
+    
+    if (!self.allowsHalfIntegralRatings) fractional = 0.5;
     
     rating = (int)rating;
     rating = rating + fractional - 0.5;


### PR DESCRIPTION
We personally don't allow ratings of 0.5, 1.5 etc
So I added a flag, leaving the default behaviour the same
