### PR TITLE
Quick fix for incorrect rating display.

### DIFF
--- a/DJWStarRatingView/DJWStarRatingView.m
+++ b/DJWStarRatingView/DJWStarRatingView.m
@@ -163,7 +163,7 @@
     float star = (float)starNumber + 1;
     if (star <= self.rating) {
         return 1.0;
-    } else if ((float)(star - 0.5) == self.rating) {
+    } else if ((float)(star - 0.5) <= self.rating) {
         return 0.5;
     } else {
         return 0;


### PR DESCRIPTION
This allows rating values like 3.7 to be displayed as 3.5.
