### PR TITLE
Invalidate intrinsic content size when needed

### DIFF
--- a/DJWStarRatingView/DJWStarRatingView.m
+++ b/DJWStarRatingView/DJWStarRatingView.m
@@ -204,12 +204,14 @@
 {
     _starSize = starSize;
     [self setNeedsDisplay];
+    [self invalidateIntrinsicContentSize];
 }
 
 - (void)setNumberOfStars:(NSInteger)numberOfStars
 {
     _numberOfStars = numberOfStars;
     [self setNeedsDisplay];
+    [self invalidateIntrinsicContentSize];
 }
 
 - (void)setRating:(float)rating
@@ -240,6 +242,7 @@
 {
     _padding = padding;
     [self setNeedsDisplay];
+    [self invalidateIntrinsicContentSize];
 }
 
 @end


### PR DESCRIPTION
Was having an issue on iOS 8 where updating the `starSize` wasn't triggering a redraw of the view. Adding these lines fixed it :+1: 
