### PR TITLE
Don't allow ratings less than 1 or more than maximum

### DIFF
--- a/DJWStarRatingView/DJWStarRatingView.m
+++ b/DJWStarRatingView/DJWStarRatingView.m
@@ -88,6 +88,7 @@
     
     rating = (int)rating;
     rating = rating + fractional - 0.5;
+    rating = MAX(1, MIN(rating, self.numberOfStars));
     return rating;
 }
 


### PR DESCRIPTION
Previously it was possible to get `rating` greater than `numberOfStars`
by using the pan gesture recognizer. This commit boxes `rating` between
1 and `numberOfStars`.
